### PR TITLE
Proposal to use git-master dependencies for collaboration, testing, and CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ readme = "README.md"
 gif = { version = "0.11.2", optional = true }
 
 [dependencies.plotters-backend]
-version = "^0.3"
+branch = "master"
+git = "https://github.com/plotters-rs/plotters-backend"
+# version = "0.3.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.image]
 version = "0.23.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,9 @@ default = ["image_encoder", "gif_backend"]
 image_encoder = ["image"]
 gif_backend = ["gif", "image_encoder"]
 
-[dev-dependencies]
-plotters = {version = "^0.3.0", default_features = false, features = ["ttf"]}
+[dev-dependencies.plotters]
+branch = "master"
+default_features = false
+features = ["ttf"]
+git = "https://github.com/plotters-rs/plotters"
+# version = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 gif = { version = "0.11.2", optional = true }
 
 [dependencies.plotters-backend]
-branch = "master"
 git = "https://github.com/plotters-rs/plotters-backend"
 # version = "0.3.1"
 
@@ -31,7 +30,6 @@ image_encoder = ["image"]
 gif_backend = ["gif", "image_encoder"]
 
 [dev-dependencies.plotters]
-branch = "master"
 default_features = false
 features = ["ttf"]
 git = "https://github.com/plotters-rs/plotters"


### PR DESCRIPTION
This proposal aims to improve collaboration, testing, and CI by altering the version of the `plotters-backend` dependency in `Cargo.toml`. Instead of using the stable version of that crate, the git-master version is used.

Using the `git-master` versions of the `plotters-` crates is vital for pre-release quality assurance and frustration-free collaboration in Plotters. It also reduces surprises at release time.

This is part of the proposal discussed on plotters-rs/plotters#373